### PR TITLE
Add Swords and Magic server

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -6,3 +6,4 @@
 # Datasource local storage ignored files
 /dataSources/
 /dataSources.local.xml
+/git_toolbox_blame.xml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,9 +493,9 @@ checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -585,7 +585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -725,16 +725,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1272,9 +1272,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "litemap"
@@ -1437,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.0"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "openssl"
@@ -1596,6 +1596,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,9 +1661,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64",
  "bytes",
@@ -1728,27 +1734,27 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustix"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.2",
- "windows-sys 0.52.0",
+ "linux-raw-sys 0.9.3",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.23"
+version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1774,9 +1780,9 @@ checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1980,6 +1986,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "swords_and_magic"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "gsm-cron",
+ "gsm-instance",
+ "gsm-monitor",
+ "gsm-notifications",
+ "gsm-serde",
+ "gsm-shared",
+ "ini-derive",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,15 +2084,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.2",
- "windows-sys 0.52.0",
+ "rustix 1.0.3",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2101,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.39"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
+checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2114,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tinystr"
@@ -2372,9 +2398,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -2504,7 +2530,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2568,9 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-registry"
@@ -2578,7 +2604,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.3.1",
+ "windows-result 0.3.2",
  "windows-strings",
  "windows-targets 0.53.0",
 ]
@@ -2594,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
  "windows-link",
 ]
@@ -2773,9 +2799,9 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]
@@ -2799,7 +2825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix 1.0.2",
+ "rustix 1.0.3",
 ]
 
 [[package]]
@@ -2920,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938cc23ac49778ac8340e366ddc422b2227ea176edb447e23fc0627608dddadd"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
  "aes",
  "arbitrary",
@@ -2933,7 +2959,7 @@ dependencies = [
  "deflate64",
  "displaydoc",
  "flate2",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "hmac",
  "indexmap",
  "lzma-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,31 @@ opt-level = 0
 [profile.release]
 opt-level = 3
 
+[workspace.dependencies]
+clap = "4.1.14"
+gsm_cron = { path = "libs/gsm-cron" }
+gsm_instance = { path = "libs/gsm-instance" }
+gsm_monitor = { path = "libs/gsm-monitor" }
+gsm_notifications = { path = "libs/gsm-notifications" }
+gsm_shared = { path = "libs/gsm-shared" }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_ini = { path = "libs/gsm-serde" }
+tokio = { version = "1.44.1", features = ["full"] }
+tracing = "0.1.41"
+
+[package]
+name = "swords_and_magic"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = "4.1.14"
+gsm_cron = { path = "../../libs/gsm-cron" }
+gsm_instance = { path = "../../libs/gsm-instance" }
+gsm_monitor = { path = "../../libs/gsm-monitor" }
+gsm_notifications = { path = "../../libs/gsm-notifications" }
+gsm_shared = { path = "../../libs/gsm-shared" }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_ini = { path = "../../libs/gsm-serde" }
+tokio = { version = "1.44.1", features = ["full"] }
+tracing = "0.1.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,31 +11,3 @@ opt-level = 0
 [profile.release]
 opt-level = 3
 
-[workspace.dependencies]
-clap = "4.1.14"
-gsm_cron = { path = "libs/gsm-cron" }
-gsm_instance = { path = "libs/gsm-instance" }
-gsm_monitor = { path = "libs/gsm-monitor" }
-gsm_notifications = { path = "libs/gsm-notifications" }
-gsm_shared = { path = "libs/gsm-shared" }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_ini = { path = "libs/gsm-serde" }
-tokio = { version = "1.44.1", features = ["full"] }
-tracing = "0.1.41"
-
-[package]
-name = "swords_and_magic"
-version = "0.1.0"
-edition = "2024"
-
-[dependencies]
-clap = "4.1.14"
-gsm_cron = { path = "../../libs/gsm-cron" }
-gsm_instance = { path = "../../libs/gsm-instance" }
-gsm_monitor = { path = "../../libs/gsm-monitor" }
-gsm_notifications = { path = "../../libs/gsm-notifications" }
-gsm_shared = { path = "../../libs/gsm-shared" }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_ini = { path = "../../libs/gsm-serde" }
-tokio = { version = "1.44.1", features = ["full"] }
-tracing = "0.1.41"

--- a/apps/swords_and_magic/Cargo.toml
+++ b/apps/swords_and_magic/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "swords_and_magic"
+version = "0.1.0"
+edition = "2024"
+repository = "https://github.com/mbround18/swords-and-magic-docker"
+
+[dependencies]
+clap = { version = "4.5.32", features = ["derive"] }
+gsm-instance = {path = "../../libs/gsm-instance"}
+gsm-cron = {path = "../../libs/gsm-cron"}
+gsm-shared = {path = "../../libs/gsm-shared"}
+gsm-monitor = {path = "../../libs/gsm-monitor"}
+gsm-notifications = {path ="../../libs/gsm-notifications"}
+gsm-serde = {path = "../../libs/gsm-serde"}
+ini-derive = {path = "../../libs/ini-derive"}
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+tokio = { version = "1.44.1", features = ["rt", "rt-multi-thread", "macros"] }
+regex = "1.11.1"

--- a/apps/swords_and_magic/src/environment.rs
+++ b/apps/swords_and_magic/src/environment.rs
@@ -1,0 +1,3 @@
+pub fn name() -> String {
+    gsm_shared::fetch_var("SNM_NAME", "My Swords and Magic Server")
+}

--- a/apps/swords_and_magic/src/game_settings.rs
+++ b/apps/swords_and_magic/src/game_settings.rs
@@ -2,32 +2,42 @@ use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs;
 use std::path::Path;
-use gsm_serde::serde_ini::{IniHeader, to_string};
+use gsm_serde::serde_ini::{IniHeader, to_string, from_str};
 
 /// Represents game settings in the server configuration.
 #[derive(Serialize, Deserialize, Debug, Clone, IniSerialize)]
 #[INIHeader(name = "/Game/Blueprints/GameModes/BP_GameInstance.BP_GameInstance_C")]
 pub struct GameSettings {
-    #[serde(rename = "ded_srv_owner_steam_id")]
-    pub ded_srv_owner_steam_id: String,
-    #[serde(rename = "ded_srv_max_players")]
-    pub ded_srv_max_players: u32,
-    #[serde(rename = "ded_srv_days_until_reset")]
-    pub ded_srv_days_until_reset: u32,
-    #[serde(rename = "ded_srv_reset_time_of_day")]
-    pub ded_srv_reset_time_of_day: String,
-    #[serde(rename = "ded_srv_reset_warnings_in_minutes")]
-    pub ded_srv_reset_warnings_in_minutes: Vec<u32>,
+    #[serde(rename = "DedSrv_OwnerSteamID")]
+    pub owner_steam_id: String,
+
+    #[serde(rename = "DedSrv_MaxPlayers")]
+    pub max_players: u32,
+
+    #[serde(rename = "DedSrv_DaysUntilReset")]
+    pub days_until_reset: u32,
+
+    #[serde(rename = "DedSrv_ResetTimeOfDay")]
+    pub reset_time_of_day: String,
+
+    #[serde(rename = "DedSrv_ResetWarningsInMinutes")]
+    pub reset_warnings_in_minutes: Vec<u32>,
 }
 
 impl Default for GameSettings {
     fn default() -> Self {
         Self {
-            ded_srv_owner_steam_id: env::var("SNM_OWNER_STEAM_ID").unwrap_or_else(|_| "00000000000000000".to_string()),
-            ded_srv_max_players: env::var("SNM_MAX_PLAYERS").unwrap_or_else(|_| "16".to_string()).parse().unwrap_or(16),
-            ded_srv_days_until_reset: env::var("SNM_DAYS_UNTIL_RESET").unwrap_or_else(|_| "1".to_string()).parse().unwrap_or(1),
-            ded_srv_reset_time_of_day: env::var("SNM_RESET_TIME_OF_DAY").unwrap_or_else(|_| "00:00".to_string()),
-            ded_srv_reset_warnings_in_minutes: vec![60, 30, 5, 1],
+            owner_steam_id: env::var("SNM_OWNER_STEAM_ID").unwrap_or_else(|_| "00000000000000000".to_string()),
+            max_players: env::var("SNM_MAX_PLAYERS")
+                .unwrap_or_else(|_| "16".to_string())
+                .parse()
+                .unwrap_or(16),
+            days_until_reset: env::var("SNM_DAYS_UNTIL_RESET")
+                .unwrap_or_else(|_| "1".to_string())
+                .parse()
+                .unwrap_or(1),
+            reset_time_of_day: env::var("SNM_RESET_TIME_OF_DAY").unwrap_or_else(|_| "00:00".to_string()),
+            reset_warnings_in_minutes: vec![60, 30, 5, 1],
         }
     }
 }
@@ -36,7 +46,7 @@ impl Default for GameSettings {
 pub fn load_or_create_config(path: &Path) -> GameSettings {
     if path.exists() {
         match fs::read_to_string(path) {
-            Ok(contents) => serde_ini::from_str::<GameSettings>(&contents).unwrap_or_else(|_| {
+            Ok(contents) => from_str::<GameSettings>(&contents).unwrap_or_else(|_| {
                 eprintln!("Warning: Corrupt config file detected. Using defaults.");
                 GameSettings::default()
             }),
@@ -47,13 +57,22 @@ pub fn load_or_create_config(path: &Path) -> GameSettings {
         }
     } else {
         eprintln!("Config file not found. Creating default config.");
-        GameSettings::default()
+        let default_config = GameSettings::default();
+        save_config(path, &default_config);
+        default_config
     }
 }
 
 /// Saves the configuration to a file.
 pub fn save_config(path: &Path, config: &GameSettings) {
-    if let Ok(ini) = to_string(config) {
-        let _ = fs::write(path, ini);
+    match to_string(config) {
+        Ok(ini) => {
+            if let Err(e) = fs::write(path, ini) {
+                eprintln!("Failed to write config file: {}", e);
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to serialize config: {}", e);
+        }
     }
 }

--- a/apps/swords_and_magic/src/game_settings.rs
+++ b/apps/swords_and_magic/src/game_settings.rs
@@ -1,0 +1,59 @@
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::fs;
+use std::path::Path;
+use gsm_serde::serde_ini::{IniHeader, to_string};
+
+/// Represents game settings in the server configuration.
+#[derive(Serialize, Deserialize, Debug, Clone, IniSerialize)]
+#[INIHeader(name = "/Game/Blueprints/GameModes/BP_GameInstance.BP_GameInstance_C")]
+pub struct GameSettings {
+    #[serde(rename = "ded_srv_owner_steam_id")]
+    pub ded_srv_owner_steam_id: String,
+    #[serde(rename = "ded_srv_max_players")]
+    pub ded_srv_max_players: u32,
+    #[serde(rename = "ded_srv_days_until_reset")]
+    pub ded_srv_days_until_reset: u32,
+    #[serde(rename = "ded_srv_reset_time_of_day")]
+    pub ded_srv_reset_time_of_day: String,
+    #[serde(rename = "ded_srv_reset_warnings_in_minutes")]
+    pub ded_srv_reset_warnings_in_minutes: Vec<u32>,
+}
+
+impl Default for GameSettings {
+    fn default() -> Self {
+        Self {
+            ded_srv_owner_steam_id: env::var("SNM_OWNER_STEAM_ID").unwrap_or_else(|_| "00000000000000000".to_string()),
+            ded_srv_max_players: env::var("SNM_MAX_PLAYERS").unwrap_or_else(|_| "16".to_string()).parse().unwrap_or(16),
+            ded_srv_days_until_reset: env::var("SNM_DAYS_UNTIL_RESET").unwrap_or_else(|_| "1".to_string()).parse().unwrap_or(1),
+            ded_srv_reset_time_of_day: env::var("SNM_RESET_TIME_OF_DAY").unwrap_or_else(|_| "00:00".to_string()),
+            ded_srv_reset_warnings_in_minutes: vec![60, 30, 5, 1],
+        }
+    }
+}
+
+/// Loads the configuration from a file or creates a new one with defaults.
+pub fn load_or_create_config(path: &Path) -> GameSettings {
+    if path.exists() {
+        match fs::read_to_string(path) {
+            Ok(contents) => serde_ini::from_str::<GameSettings>(&contents).unwrap_or_else(|_| {
+                eprintln!("Warning: Corrupt config file detected. Using defaults.");
+                GameSettings::default()
+            }),
+            Err(_) => {
+                eprintln!("Failed to read config file. Using defaults.");
+                GameSettings::default()
+            }
+        }
+    } else {
+        eprintln!("Config file not found. Creating default config.");
+        GameSettings::default()
+    }
+}
+
+/// Saves the configuration to a file.
+pub fn save_config(path: &Path, config: &GameSettings) {
+    if let Ok(ini) = to_string(config) {
+        let _ = fs::write(path, ini);
+    }
+}

--- a/apps/swords_and_magic/src/game_settings.rs
+++ b/apps/swords_and_magic/src/game_settings.rs
@@ -1,8 +1,9 @@
+use gsm_serde::serde_ini::{IniHeader, from_str, to_string};
+use ini_derive::IniSerialize;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs;
 use std::path::Path;
-use gsm_serde::serde_ini::{IniHeader, to_string, from_str};
 
 /// Represents game settings in the server configuration.
 #[derive(Serialize, Deserialize, Debug, Clone, IniSerialize)]
@@ -27,7 +28,8 @@ pub struct GameSettings {
 impl Default for GameSettings {
     fn default() -> Self {
         Self {
-            owner_steam_id: env::var("SNM_OWNER_STEAM_ID").unwrap_or_else(|_| "00000000000000000".to_string()),
+            owner_steam_id: env::var("SNM_OWNER_STEAM_ID")
+                .unwrap_or_else(|_| "00000000000000000".to_string()),
             max_players: env::var("SNM_MAX_PLAYERS")
                 .unwrap_or_else(|_| "16".to_string())
                 .parse()
@@ -36,7 +38,8 @@ impl Default for GameSettings {
                 .unwrap_or_else(|_| "1".to_string())
                 .parse()
                 .unwrap_or(1),
-            reset_time_of_day: env::var("SNM_RESET_TIME_OF_DAY").unwrap_or_else(|_| "00:00".to_string()),
+            reset_time_of_day: env::var("SNM_RESET_TIME_OF_DAY")
+                .unwrap_or_else(|_| "00:00".to_string()),
             reset_warnings_in_minutes: vec![60, 30, 5, 1],
         }
     }

--- a/apps/swords_and_magic/src/main.rs
+++ b/apps/swords_and_magic/src/main.rs
@@ -12,7 +12,6 @@ use std::env;
 use std::path::PathBuf;
 use std::process::exit;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
@@ -76,7 +75,8 @@ async fn main() {
                 error!("Installation failed: {}", e);
             } else {
                 debug!("Installation successful.");
-                let config_path = path.join("SNM2020/Saved/Config/WindowsServer/GameUserSettings.ini");
+                let config_path =
+                    path.join("SNM2020/Saved/Config/WindowsServer/GameUserSettings.ini");
                 game_settings::load_or_create_config(&config_path);
             }
         }
@@ -99,37 +99,37 @@ async fn main() {
             let rules = LogRules::default();
 
             if env::var("WEBHOOK_URL").is_ok() {
-                rules.add_rule(
-                    |line| line.contains("[Session] 'HostOnline' (up)!"),
-                    |_| {
-                        send_notifications(StandardServerEvents::Started)
-                            .expect("Failed to send webhook event! Invalid url?")
-                    },
-                    false,
-                    None,
-                );
-
-                rules.add_rule(
-                    |line| line.contains("logged in with Permissions:"),
-                    |line| match utils::extract_player_joined_name(line) {
-                        Some(name) => send_notifications(StandardServerEvents::PlayerJoined(name))
-                            .expect("Failed to send webhook event! Invalid url?"),
-                        None => error!("Failed to extract player name from:\n{line}"),
-                    },
-                    false,
-                    None,
-                );
-
-                rules.add_rule(
-                    |line| line.contains("[server] Remove Entity for Player"),
-                    |line| match utils::extract_player_left_name(line) {
-                        Some(name) => send_notifications(StandardServerEvents::PlayerLeft(name))
-                            .expect("Failed to send webhook event! Invalid url?"),
-                        None => error!("Failed to extract player name from:\n{line}"),
-                    },
-                    false,
-                    None,
-                );
+                // rules.add_rule(
+                //     |line| line.contains("[Session] 'HostOnline' (up)!"),
+                //     |_| {
+                //         send_notifications(StandardServerEvents::Started)
+                //             .expect("Failed to send webhook event! Invalid url?")
+                //     },
+                //     false,
+                //     None,
+                // );
+                //
+                // rules.add_rule(
+                //     |line| line.contains("logged in with Permissions:"),
+                //     |line| match utils::extract_player_joined_name(line) {
+                //         Some(name) => send_notifications(StandardServerEvents::PlayerJoined(name))
+                //             .expect("Failed to send webhook event! Invalid url?"),
+                //         None => error!("Failed to extract player name from:\n{line}"),
+                //     },
+                //     false,
+                //     None,
+                // );
+                //
+                // rules.add_rule(
+                //     |line| line.contains("[server] Remove Entity for Player"),
+                //     |line| match utils::extract_player_left_name(line) {
+                //         Some(name) => send_notifications(StandardServerEvents::PlayerLeft(name))
+                //             .expect("Failed to send webhook event! Invalid url?"),
+                //         None => error!("Failed to extract player name from:\n{line}"),
+                //     },
+                //     false,
+                //     None,
+                // );
             }
 
             gsm_monitor::start_instance_log_monitor(working_dir, rules);

--- a/apps/swords_and_magic/src/main.rs
+++ b/apps/swords_and_magic/src/main.rs
@@ -1,0 +1,222 @@
+mod environment;
+mod game_settings;
+
+use crate::environment::name;
+use clap::{Parser, Subcommand};
+use gsm_cron::{begin_cron_loop, register_job};
+use gsm_instance::{Instance, InstanceConfig};
+use gsm_monitor::LogRules;
+use gsm_notifications::notifications::{StandardServerEvents, send_notifications};
+use gsm_shared::{fetch_var, is_env_var_truthy};
+use std::env;
+use std::path::PathBuf;
+use std::process::exit;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tracing::{debug, error, info, warn};
+
+#[derive(Parser)]
+#[command(
+    name = "swords_and_magic",
+    version = "1.0",
+    about = "Manage Swords and Magic Server"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Install {
+        #[arg(long, default_value = "/home/steam/swords_and_magic")]
+        path: PathBuf,
+    },
+    Start,
+    Monitor {
+        #[arg(long)]
+        update_job: bool,
+        #[arg(long)]
+        restart_job: bool,
+    },
+    Stop,
+    Restart,
+    Update {
+        #[arg(long)]
+        check: bool,
+    },
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    debug!("Tracing subscriber initialized.");
+
+    let cli = Cli::parse();
+    let instance_config = InstanceConfig {
+        app_id: 2058450, // Swords and Magic Steam App ID
+        name: name(),
+        command: "SNMASServer.exe".to_string(),
+        install_args: vec![],
+        launch_args: vec![],
+        force_windows: true,
+        working_dir: PathBuf::from("/home/steam/swords_and_magic"),
+    };
+    debug!("Instance configuration set: {:?}", instance_config);
+
+    let instance = Arc::new(Mutex::new(Instance::new(instance_config)));
+    debug!("Instance created and wrapped in Arc<Mutex<>>");
+
+    match cli.command {
+        Commands::Install { path } => {
+            info!("Installing Swords and Magic server to: {:?}", path);
+            let inst = instance.lock().await;
+            if let Err(e) = inst.install() {
+                error!("Installation failed: {}", e);
+            } else {
+                debug!("Installation successful.");
+                let config_path = path.join("SNM2020/Saved/Config/WindowsServer/GameUserSettings.ini");
+                game_settings::load_or_create_config(&config_path);
+            }
+        }
+        Commands::Start => {
+            info!("Starting server...");
+            let inst = instance.lock().await;
+            if let Err(e) = inst.start() {
+                error!("Failed to start server: {}", e);
+            }
+        }
+        Commands::Monitor {
+            update_job,
+            restart_job,
+        } => {
+            let working_dir = {
+                let inst = instance.lock().await;
+                inst.config.working_dir.clone()
+            };
+
+            let rules = LogRules::default();
+
+            if env::var("WEBHOOK_URL").is_ok() {
+                rules.add_rule(
+                    |line| line.contains("[Session] 'HostOnline' (up)!"),
+                    |_| {
+                        send_notifications(StandardServerEvents::Started)
+                            .expect("Failed to send webhook event! Invalid url?")
+                    },
+                    false,
+                    None,
+                );
+
+                rules.add_rule(
+                    |line| line.contains("logged in with Permissions:"),
+                    |line| match utils::extract_player_joined_name(line) {
+                        Some(name) => send_notifications(StandardServerEvents::PlayerJoined(name))
+                            .expect("Failed to send webhook event! Invalid url?"),
+                        None => error!("Failed to extract player name from:\n{line}"),
+                    },
+                    false,
+                    None,
+                );
+
+                rules.add_rule(
+                    |line| line.contains("[server] Remove Entity for Player"),
+                    |line| match utils::extract_player_left_name(line) {
+                        Some(name) => send_notifications(StandardServerEvents::PlayerLeft(name))
+                            .expect("Failed to send webhook event! Invalid url?"),
+                        None => error!("Failed to extract player name from:\n{line}"),
+                    },
+                    false,
+                    None,
+                );
+            }
+
+            gsm_monitor::start_instance_log_monitor(working_dir, rules);
+
+            if update_job || is_env_var_truthy("AUTO_UPDATE") {
+                let update_schedule = fetch_var("AUTO_UPDATE_SCHEDULE", "0 3 * * *");
+                let instance_clone = Arc::clone(&instance);
+                register_job("auto-update", &update_schedule, move || {
+                    let instance_clone_inner = Arc::clone(&instance_clone);
+                    tokio::spawn(async move {
+                        let inst = instance_clone_inner.lock().await;
+                        if inst.update_available() {
+                            warn!("Update available! Stopping server...");
+                            if let Err(e) = inst.stop() {
+                                error!("Failed to stop server: {}", e);
+                                return;
+                            }
+                            info!("Updating server...");
+                            if let Err(e) = inst.update() {
+                                error!("Update failed: {}", e);
+                                return;
+                            }
+                            info!("Restarting server...");
+                            if let Err(e) = inst.start() {
+                                error!("Failed to start server: {}", e);
+                            }
+                        }
+                    });
+                });
+            }
+
+            if restart_job || is_env_var_truthy("SCHEDULED_RESTART") {
+                let restart_schedule = fetch_var("SCHEDULED_RESTART_SCHEDULE", "0 4 * * *");
+                let instance_clone = Arc::clone(&instance);
+                register_job("scheduled-restart", &restart_schedule, move || {
+                    let instance_clone_inner = Arc::clone(&instance_clone);
+                    tokio::spawn(async move {
+                        let inst = instance_clone_inner.lock().await;
+                        warn!("Restarting server...");
+                        if let Err(e) = inst.restart() {
+                            error!("Failed to restart server: {}", e);
+                        }
+                    });
+                });
+            }
+
+            begin_cron_loop().await;
+        }
+        Commands::Stop => {
+            warn!("Stopping Swords and Magic server...");
+            let inst = instance.lock().await;
+            match inst.stop() {
+                Err(e) => {
+                    error!("Failed to stop: {}", e);
+                }
+                Ok(_) => {
+                    if env::var("WEBHOOK_URL").is_ok() {
+                        send_notifications(StandardServerEvents::Stopped)
+                            .expect("Failed to send webhook event! Invalid url?");
+                    }
+                    debug!("Server stopped successfully.");
+                }
+            }
+        }
+        Commands::Restart => {
+            warn!("Restarting Swords and Magic server...");
+            let inst = instance.lock().await;
+            if let Err(e) = inst.restart() {
+                error!("Failed to restart server: {}", e);
+            }
+        }
+        Commands::Update { check } => {
+            let inst = instance.lock().await;
+            if check {
+                if inst.update_available() {
+                    info!("Update available!");
+                    exit(1);
+                } else {
+                    info!("Server is up to date.");
+                    exit(0);
+                }
+            } else if inst.update_available() {
+                warn!("Update available! Updating...");
+                if let Err(e) = inst.update() {
+                    error!("Update failed: {}", e);
+                }
+            }
+        }
+    }
+}

--- a/libs/gsm-backup/Cargo.toml
+++ b/libs/gsm-backup/Cargo.toml
@@ -11,4 +11,4 @@ tar = "0.4"
 thiserror = "2"
 
 [dev-dependencies]
-tempfile = "3.18"
+tempfile = "3.19"

--- a/libs/gsm-instance/Cargo.toml
+++ b/libs/gsm-instance/Cargo.toml
@@ -8,7 +8,7 @@ daemonize = "0"
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = "2.0.12"
 tracing = "0.1"
-tempfile = "3.18.0"
+tempfile = "3.19.1"
 which = "7.0.2"
 sysinfo = "0"
 regex = "1.11.1"

--- a/libs/gsm-mod-manager/Cargo.toml
+++ b/libs/gsm-mod-manager/Cargo.toml
@@ -9,9 +9,9 @@ path = "src/lib.rs"
 
 [dependencies]
 tracing = "0.1"
-tempfile = "3.18.0"
+tempfile = "3.19.1"
 walkdir = "2.5.0"
-zip = "2.2.3"
+zip = "2.4.2"
 fs_extra = "1"
 thiserror = "2"
 regex = "1"

--- a/libs/gsm-notifications/Cargo.toml
+++ b/libs/gsm-notifications/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-reqwest = "0.12.14"
+reqwest = "0.12.15"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 gsm-shared = {path = "../gsm-shared"}

--- a/libs/gsm-shared/Cargo.toml
+++ b/libs/gsm-shared/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 serde = {version = "1",features = ["derive", "default"] }
 tracing = "0.1"
-tempfile = "3.18.0"
+tempfile = "3.19.1"
 walkdir = "2.5.0"
 reqwest = {version = "0", features = ["json", "default-tls", "blocking"]}
 cached = "0"


### PR DESCRIPTION
Add dedicated server setup for Swords and Magic and Stuff.

* **Environment Variable Handling**
  - Add `name` function in `apps/swords_and_magic/src/environment.rs` to fetch server name from environment variable `SNM_NAME`.

* **Game Settings Configuration**
  - Define `GameSettings` struct in `apps/swords_and_magic/src/game_settings.rs` with relevant configuration settings.
  - Implement `Default` for `GameSettings` to provide default values.
  - Add `load_or_create_config` function to load or create configuration using `serde_ini`.
  - Add `save_config` function to save configuration to an INI file using `serde_ini`.
  - Add `serde` renames to each field to ensure they use snake_case.

* **Main Application Logic**
  - Add `Cli` struct with subcommands for `Install`, `Start`, `Monitor`, `Stop`, `Restart`, and `Update` in `apps/swords_and_magic/src/main.rs`.
  - Implement main function to parse CLI arguments and execute corresponding commands.
  - Add logic to handle `Install`, `Start`, `Monitor`, `Stop`, `Restart`, and `Update` commands.

* **Dependencies**
  - Modify `Cargo.toml` to add new package for `swords_and_magic` with necessary dependencies.
  - Add `serde_ini` as a dependency for `swords_and_magic`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mbround18/game-server-management/pull/41?shareId=8c6c9768-53c7-4c3e-9e4c-17378cbf31fe).