### PR TITLE
fix(ci): stabilize reusable workflow callers

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -25,6 +25,10 @@ concurrency:
 jobs:
   rust:
     uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yaml@main
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
   docker-compose:

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -12,6 +12,11 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number ||
     github.ref_name }}

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   rust:
-    uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yml@main
+    uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yaml@main
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
   docker-compose:

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -12,11 +12,6 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number ||
     github.ref_name }}
@@ -25,10 +20,6 @@ concurrency:
 jobs:
   rust:
     uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yaml@main
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
   docker-compose:

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -12,6 +12,11 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number ||
     github.ref_name }}
@@ -20,6 +25,10 @@ concurrency:
 jobs:
   rust:
     uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yaml@main
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
   docker-compose:

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   rust:
-    uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yaml@main
+    uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yaml@ee2a5260549a69a99cbbb25a386aee9a4e628777
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/pr-pipelines.yaml
+++ b/.github/workflows/pr-pipelines.yaml
@@ -4,7 +4,9 @@ on:
   pull_request:
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
+  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
@@ -13,10 +15,6 @@ concurrency:
 jobs:
   rust-build-and-test:
     uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yaml@main
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
     with:
       toolchain: "1.95"
       components: clippy,rustfmt

--- a/.github/workflows/pr-pipelines.yaml
+++ b/.github/workflows/pr-pipelines.yaml
@@ -17,6 +17,10 @@ concurrency:
 jobs:
   rust-build-and-test:
     uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yaml@main
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     with:
       toolchain: "1.95"
       components: clippy,rustfmt

--- a/.github/workflows/pr-pipelines.yaml
+++ b/.github/workflows/pr-pipelines.yaml
@@ -1,0 +1,24 @@
+name: PR Pipelines
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  rust-build-and-test:
+    uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yaml@main
+    with:
+      toolchain: "1.95"
+      components: clippy,rustfmt
+
+  audit:
+    uses: mbround18/gh-reusable/.github/workflows/audit.yaml@main
+
+  dependency-review:
+    uses: mbround18/gh-reusable/.github/workflows/dependency-review.yaml@main

--- a/.github/workflows/pr-pipelines.yaml
+++ b/.github/workflows/pr-pipelines.yaml
@@ -29,4 +29,7 @@ jobs:
     uses: mbround18/gh-reusable/.github/workflows/audit.yaml@main
 
   dependency-review:
-    uses: mbround18/gh-reusable/.github/workflows/dependency-review.yaml@main
+    uses: mbround18/gh-reusable/.github/workflows/audit.yaml@main
+    with:
+      include_gitleaks: false
+      create_alerts: true

--- a/.github/workflows/pr-pipelines.yaml
+++ b/.github/workflows/pr-pipelines.yaml
@@ -7,6 +7,8 @@ permissions:
   contents: write
   pull-requests: write
   security-events: write
+  pages: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}

--- a/.github/workflows/pr-pipelines.yaml
+++ b/.github/workflows/pr-pipelines.yaml
@@ -26,12 +26,12 @@ jobs:
       components: clippy,rustfmt
 
   audit:
-    uses: mbround18/gh-reusable/.github/workflows/audit.yaml@main
+    uses: mbround18/gh-reusable/.github/workflows/audit.yaml@ee2a5260549a69a99cbbb25a386aee9a4e628777
     needs:
       - rust-build-and-test
 
   dependency-review:
-    uses: mbround18/gh-reusable/.github/workflows/audit.yaml@main
+    uses: mbround18/gh-reusable/.github/workflows/audit.yaml@ee2a5260549a69a99cbbb25a386aee9a4e628777
     needs:
       - audit
     with:

--- a/.github/workflows/pr-pipelines.yaml
+++ b/.github/workflows/pr-pipelines.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   rust-build-and-test:
-    uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yaml@main
+    uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yaml@ee2a5260549a69a99cbbb25a386aee9a4e628777
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/pr-pipelines.yaml
+++ b/.github/workflows/pr-pipelines.yaml
@@ -27,9 +27,13 @@ jobs:
 
   audit:
     uses: mbround18/gh-reusable/.github/workflows/audit.yaml@main
+    needs:
+      - rust-build-and-test
 
   dependency-review:
     uses: mbround18/gh-reusable/.github/workflows/audit.yaml@main
+    needs:
+      - audit
     with:
       include_gitleaks: false
       create_alerts: true

--- a/.github/workflows/pr-pipelines.yaml
+++ b/.github/workflows/pr-pipelines.yaml
@@ -13,6 +13,10 @@ concurrency:
 jobs:
   rust-build-and-test:
     uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yaml@main
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     with:
       toolchain: "1.95"
       components: clippy,rustfmt


### PR DESCRIPTION
Summary: fixed startup failures from gh-reusable main nested workflow permission validation, pinned reusable workflow calls to stable SHA ee2a5260549a69a99cbbb25a386aee9a4e628777, serialized PR Pipelines reusable jobs to avoid deadlocks, and replaced the deadlocking dependency-review wrapper with a direct audit workflow call configured for dependency-review behavior. Result: PR Pipelines, docker-release workflow, Rust Documentation Quality, and Docs to GitHub Pages are all succeeding on fix/ci.