### PR TITLE
ci: publish Rust crates on tag releases

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
   pages: write
   id-token: write
 
@@ -30,6 +31,15 @@ jobs:
       pages: write
       id-token: write
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+  publish-crates:
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    uses: mbround18/gh-reusable/.github/workflows/publish.yaml@ee2a5260549a69a99cbbb25a386aee9a4e628777
+    with:
+      target: rust-crate
+      registry: crates.io
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
   docker-compose:
     needs:


### PR DESCRIPTION
Summary: add a publish-crates job in .github/workflows/docker-release.yaml for v* tags, call gh-reusable publish workflow pinned to ee2a5260549a69a99cbbb25a386aee9a4e628777, map secrets.CRATES_IO_TOKEN to CARGO_REGISTRY_TOKEN, and grant packages: write permission needed by the publish workflow. Expected behavior: when a v* tag is pushed, CI publishes Rust crates to crates.io using secrets.CRATES_IO_TOKEN.