### PR TITLE
Migrate CI from gh-reusable to paws

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -15,21 +15,24 @@ on:
 permissions:
   contents: read
   packages: write
-  pages: write
-  id-token: write
 
 jobs:
   rust:
-    uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yaml@main
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
+    runs-on: ubuntu-latest
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # de0fac2, https://github.com/actions/checkout/releases/latest
+
+      - name: Install paws
+        uses: mbround18/paws/actions/paws-up@1315105b98074f2dbde6b16615d1219dbfe4a0f6 # v0.0.1-prerelease.36, https://github.com/mbround18/paws/releases/latest
+
+      - name: Rust CI (build, test, clippy, rustfmt)
+        run: paws ci --toolchain rust
 
   publish-crates:
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    uses: mbround18/gh-reusable/.github/workflows/publish.yaml@main
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -44,12 +47,17 @@ jobs:
           - libs/gsm-mod-manager
           - libs/gsm-notifications
           - libs/gsm-serde
-    with:
-      target: rust-crate
-      source: ${{ matrix.source }}
-      registry: crates.io
-    secrets:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # de0fac2, https://github.com/actions/checkout/releases/latest
+
+      - name: Install paws
+        uses: mbround18/paws/actions/paws-up@1315105b98074f2dbde6b16615d1219dbfe4a0f6 # v0.0.1-prerelease.36, https://github.com/mbround18/paws/releases/latest
+
+      - name: Publish crate
+        run: paws publish --target rust-crate --source ${{ matrix.source }} --registry crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
   docker-compose:
     needs:

--- a/.github/workflows/pr-pipelines.yaml
+++ b/.github/workflows/pr-pipelines.yaml
@@ -4,11 +4,7 @@ on:
   pull_request:
 
 permissions:
-  contents: write
-  pull-requests: write
-  security-events: write
-  pages: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
@@ -16,24 +12,29 @@ concurrency:
 
 jobs:
   rust-build-and-test:
-    uses: mbround18/gh-reusable/.github/workflows/rust-build-n-test.yaml@ee2a5260549a69a99cbbb25a386aee9a4e628777
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    with:
-      toolchain: "1.95"
-      components: clippy,rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # de0fac2, https://github.com/actions/checkout/releases/latest
+
+      - name: Install paws
+        uses: mbround18/paws/actions/paws-up@1315105b98074f2dbde6b16615d1219dbfe4a0f6 # v0.0.1-prerelease.36, https://github.com/mbround18/paws/releases/latest
+
+      - name: Rust CI (build, test, clippy, rustfmt)
+        run: paws ci --toolchain rust
 
   audit:
-    uses: mbround18/gh-reusable/.github/workflows/audit.yaml@ee2a5260549a69a99cbbb25a386aee9a4e628777
+    runs-on: ubuntu-latest
     needs:
       - rust-build-and-test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # de0fac2, https://github.com/actions/checkout/releases/latest
+        with:
+          fetch-depth: 0
 
-  dependency-review:
-    uses: mbround18/gh-reusable/.github/workflows/audit.yaml@ee2a5260549a69a99cbbb25a386aee9a4e628777
-    needs:
-      - audit
-    with:
-      include_gitleaks: false
-      create_alerts: true
+      - name: Install paws
+        uses: mbround18/paws/actions/paws-up@1315105b98074f2dbde6b16615d1219dbfe4a0f6 # v0.0.1-prerelease.36, https://github.com/mbround18/paws/releases/latest
+
+      - name: Audit (semgrep + gitleaks)
+        run: paws audit

--- a/apps/enshrouded/src/main.rs
+++ b/apps/enshrouded/src/main.rs
@@ -81,6 +81,7 @@ async fn main() {
         force_windows: true,
         working_dir: PathBuf::from("/home/steam/enshrouded"),
         launch_mode: gsm_instance::config::LaunchMode::Wine,
+        skip_validate: false,
     };
     debug!("Instance configuration set: {:?}", instance_config);
 

--- a/apps/gsm-cli/src/main.rs
+++ b/apps/gsm-cli/src/main.rs
@@ -168,6 +168,7 @@ impl ResolvedOptions {
             force_windows: self.force_windows,
             working_dir: self.install_path,
             launch_mode: self.launch_mode,
+            skip_validate: false,
         }
     }
 }

--- a/apps/palworld/src/main.rs
+++ b/apps/palworld/src/main.rs
@@ -87,6 +87,7 @@ async fn main() {
         force_windows: false,
         launch_mode: gsm_instance::config::LaunchMode::Native,
         working_dir: PathBuf::from("/home/steam/palworld"),
+        skip_validate: false,
     };
     debug!("Instance configuration set: {:?}", instance_config);
 

--- a/libs/gsm-serde/src/serde_ini.rs
+++ b/libs/gsm-serde/src/serde_ini.rs
@@ -247,25 +247,18 @@ pub fn to_string_compact<T: Serialize + IniHeader>(value: &T) -> Result<String, 
         let entry_count = entries.len();
         for (i, (key, val)) in entries.into_iter().enumerate() {
             let is_last = i + 1 == entry_count;
-            match val {
-                serde_json::Value::Object(_) => {
-                    output.push_str(&key);
-                    output.push_str("=(");
-                    output.push_str(&serialize_value(&val, 0, true));
-                    output.push(')');
-                    if !is_last {
-                        output.push(',');
-                    }
-                    output.push('\n');
-                }
-                _ => {
-                    let _ = write!(output, "{key}={}", format_json_value(&val));
-                    if !is_last {
-                        output.push(',');
-                    }
-                    output.push('\n');
-                }
+            if let serde_json::Value::Object(_) = val {
+                output.push_str(&key);
+                output.push_str("=(");
+                output.push_str(&serialize_value(&val, 0, true));
+                output.push(')');
+            } else {
+                let _ = write!(output, "{key}={}", format_json_value(&val));
             }
+            if !is_last {
+                output.push(',');
+            }
+            output.push('\n');
         }
     }
 


### PR DESCRIPTION
## Summary
- Replaces the `mbround18/gh-reusable` reusable workflows with the `paws` CLI (`mbround18/paws/actions/paws-up`) across `pr-pipelines.yaml` and `docker-release.yaml`.
- `pr-pipelines.yaml`: build/test now runs `paws ci --toolchain rust`; audit (semgrep + gitleaks) now runs `paws audit`. Dropped the separate `dependency-review` job since `paws audit` has no equivalent create-alerts/no-gitleaks variant.
- `docker-release.yaml`: the pre-tag rust job runs `paws ci --toolchain rust`; the tag-triggered crates.io publish job now runs `paws publish --target rust-crate --source <crate> --registry crates.io` per crate in the matrix, reading `CARGO_REGISTRY_TOKEN` from the existing `CRATES_IO_TOKEN` secret.
- `docker-compose` job is untouched (never depended on gh-reusable).

## Test plan
- [ ] Confirm `rust-build-and-test` (pr-pipelines.yaml) passes on this PR
- [ ] Confirm `audit` (pr-pipelines.yaml) passes on this PR
- [ ] Confirm `rust` job in docker-release.yaml passes on this PR
- [ ] Push a test tag (or dry-run) to confirm `paws publish --target rust-crate` successfully publishes to crates.io using `CRATES_IO_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)